### PR TITLE
Add missing connection param support and unit-tests

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -42,6 +42,23 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-launcher</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -64,7 +81,6 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>${mvn.processor.plugin.version}</version>
                 <configuration>
                     <processors>
                         <processor>org.ballerinalang.codegen.BallerinaAnnotationProcessor</processor>
@@ -87,7 +103,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven.checkstyle.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>validate</id>
@@ -117,7 +132,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -165,7 +179,6 @@
             <plugin>
                 <groupId>org.ballerinalang</groupId>
                 <artifactId>docerina-maven-plugin</artifactId>
-                <version>${docerina.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -210,6 +223,103 @@
                             <resourceBundles>
                                 <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
                             </resourceBundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <findbugsXmlOutputDirectory>
+                        ${project.build.directory}/findbugs
+                    </findbugsXmlOutputDirectory>
+                    <excludeFilterFile>${maven.findbugsplugin.version.exclude}</excludeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                        <version>${findbugs.annotations.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <argLine>@{argLine} -Dlog4j.configuration=src/test/resources/log4j-surefire.properties</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit >
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit >
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                    <excludes>
+                                        <exclude>*Test</exclude>
+                                        <exclude>**/generated/**</exclude>
+                                    </excludes>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
+                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/component/src/main/ballerina/ballerina/data/cassandra/natives.bal
+++ b/component/src/main/ballerina/ballerina/data/cassandra/natives.bal
@@ -1,35 +1,181 @@
 package ballerina.data.cassandra;
 
-@Description { value: "Parameter struct represents a query parameter for the queries specified in connector actions."}
+@Description {value:"Parameter struct represents a query parameter for the queries specified in connector actions."}
 @Field {value:"cqlType: The cassandra data type of the corresponding parameter"}
-@Field {value:"value: Value of paramter pass into the query"}
+@Field {value:"value: Value of parameter passed into the query"}
 public struct Parameter {
     Type cqlType;
     any value;
 }
 
-@Description { value: "ConnectionProperties structs represents the properties which are used to configure cassandra connection."}
+@Description {value:"ConnectionProperties structs represents the properties which are used to configure cassandra
+connection"}
+@Field {value:"clusterName: The name of the cluster object"}
+@Field {value:"loadBalancingPolicy: The policy that decides which Cassandra hosts to contact for each new query"}
+@Field {value:"reconnectionPolicy: The policy that schedules reconnection attempts to a node"}
+@Field {value:"retryPolicy: The policy that defines a default behavior to adopt when a request fails"}
+@Field {value:"dataCenter: The data center used with DCAwareRoundRobinPolicy"}
+@Field {value:"withoutMetrics: Disables metrics collection for the created cluster if true"}
+@Field {value:"withoutJMXReporting: Disables JMX reporting of the metrics if true"}
+@Field {value:"allowRemoteDCsForLocalConsistencyLevel: Determine whether to allow DCAwareRoundRobinPolicy to return
+remote hosts when building query plans for queries having consistency level LOCAL_ONE or LOCAL_QUORUM"}
+@Field {value:"constantReconnectionPolicyDelay: The constant wait time between reconnection attempts of
+ConstantReconnectionPolicy"}
+@Field {value:"exponentialReconnectionPolicyBaseDelay: The base delay in milliseconds for
+ExponentialReconnectionPolicy"}
+@Field {value:"The maximum delay in milliseconds between reconnection attempts of ExponentialReconnectionPolicy"}
+@Field {value:"queryOptionsConfig: Options related to defaults for individual queries"}
+@Field {value:"poolingOptionsConfig: Options related to connection pooling"}
+@Field {value:"socketOptionsConfig: Options to configure low-level socket options for the connections kept to the
+Cassandra hosts"}
+@Field {value:"protocolOptionsConfig: Options of the Cassandra native binary protocol"}
+public struct ConnectionProperties {
+    string clusterName;
+    string loadBalancingPolicy;
+    string reconnectionPolicy;
+    string retryPolicy;
+    string dataCenter;
+
+    boolean withoutMetrics = false;
+    boolean withoutJMXReporting = false;
+    boolean allowRemoteDCsForLocalConsistencyLevel = false;
+
+    int constantReconnectionPolicyDelay = -1;
+    int exponentialReconnectionPolicyBaseDelay = -1;
+    int exponentialReconnectionPolicyMaxDelay = -1;
+
+    QueryOptionsConfiguration queryOptionsConfig;
+    PoolingOptionsConfiguration poolingOptionsConfig;
+    SocketOptionsConfiguration socketOptionsConfig;
+    ProtocolOptionsConfiguration protocolOptionsConfig;
+}
+
+@Description {value:"Options of the Cassandra native binary protocol"}
+@Field {value:"sslEnabled: Enables the use of SSL for the created Cluster"}
+@Field {value:"noCompact: Whether or not to include the NO_COMPACT startup option"}
+@Field {value:"maxSchemaAgreementWaitSeconds: The maximum time to wait for schema agreement before returning from a
+DDL query"}
+@Field {value:"initialProtocolVersion: Version of the native protocol supported by the driver"}
+@Field {value:"compression: Compression supported by the Cassandra binary protocol"}
+public struct ProtocolOptionsConfiguration {
+    boolean sslEnabled;
+    boolean noCompact;
+
+    int maxSchemaAgreementWaitSeconds = -1;
+
+    string initialProtocolVersion;
+    string compression;
+}
+
+@Description {value:"Options related to defaults for individual queries"}
 @Field {value:"consistencyLevel: Determines how many nodes in the replica must respond for the coordinator node to
 successfully process a non-lightweight transaction. Supported values are ANY, ONE, TWO, THREE, QUORUM,
  ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE"}
-@Field {value:"sslEnabled: Enables the use of SSL for the created Cluster"}
+@Field {value:"serialConsistencyLevel: The serial consistency level is only used by conditional updates
+(INSERT, UPDATE or DELETE statements with an IF condition). For those, the serial consistency level
+defines the consistency level of the serial phase (or 'paxos' phase) while the normal consistency level
+defines the consistency for the 'learn' phase. Supported values are SERIAL, LOCAL_SERIAL"}
+@Field {value:"defaultIdempotence: A statement is idempotent if it can be applied multiple times without changing the
+result beyond the initial application"}
+@Field {value:"metadataEnabled: Toggles client-side token and schema metadata enablement"}
+@Field {value:"reprepareOnUp: Determines whether the driver should re-prepare all cached prepared statements on a host
+when it marks it back up"}
+@Field {value:"prepareOnAllHosts: Determines whether the driver should prepare statements on all hosts in the cluster"}
 @Field {value:"fetchSize:Sets the default fetch size to use for SELECT queries"}
-public struct ConnectionProperties {
+@Field {value:"maxPendingRefreshNodeListRequests: Determines the maximum number of node list refresh requests that
+the control connection can accumulate before executing them"}
+@Field {value:"maxPendingRefreshNodeRequests: Determines the maximum number of node refresh requests that the control
+connection can accumulate before executing them"}
+@Field {value:"maxPendingRefreshSchemaRequests: Determines the maximum number of schema refresh requests that the
+control connection can accumulate before executing them"}
+@Field {value:"refreshNodeListIntervalMillis: Determines the default window size in milliseconds used to debounce node
+list refresh requests"}
+@Field {value:"refreshNodeIntervalMillis: Determines the default window size in milliseconds used to debounce node
+refresh requests"}
+@Field {value:"refreshSchemaIntervalMillis: Determines the default window size in milliseconds used to debounce node
+list refresh requests"}
+public struct QueryOptionsConfiguration {
     string consistencyLevel;
-    boolean sslEnabled;
+    string serialConsistencyLevel;
+
+    boolean defaultIdempotence = false;
+    boolean metadataEnabled = true;
+    boolean reprepareOnUp = true;
+    boolean prepareOnAllHosts = true;
+
     int fetchSize = -1;
+    int maxPendingRefreshNodeListRequests = -1;
+    int maxPendingRefreshNodeRequests = -1;
+    int maxPendingRefreshSchemaRequests = -1;
+    int refreshNodeListIntervalMillis = -1;
+    int refreshNodeIntervalMillis = -1;
+    int refreshSchemaIntervalMillis = -1;
+}
+
+@Description {value:"Options related to connection pooling"}
+@Field {value:"maxRequestsPerConnectionLocal: The maximum number of requests per connection for local hosts"}
+@Field {value:"maxRequestsPerConnectionRemote: The maximum number of requests per connection for remote hosts"}
+@Field {value:"idleTimeoutSeconds: The timeout before an idle connection is removed"}
+@Field {value:"poolTimeoutMillis: The timeout when trying to acquire a connection from a host's pool"}
+@Field {value:"maxQueueSize: The maximum number of requests that get enqueued if no connection is available"}
+@Field {value:"heartbeatIntervalSeconds: The heart beat interval, after which a message is sent on an idle connection
+to make sure it's still alive"}
+@Field {value:"coreConnectionsPerHostLocal: The core number of connections per local host"}
+@Field {value:"maxConnectionsPerHostLocal: The maximum number of connections per local host"}
+@Field {value:"newConnectionThresholdLocal: The threshold that triggers the creation of a new connection to a
+local host"}
+@Field {value:"coreConnectionsPerHostRemote: The core number of connections per remote host"}
+@Field {value:"maxConnectionsPerHostRemote: The maximum number of connections per remote host"}
+@Field {value:"newConnectionThresholdRemote: The threshold that triggers the creation of a new connection to a
+remote host"}
+public struct PoolingOptionsConfiguration {
+    int maxRequestsPerConnectionLocal = -1;
+    int maxRequestsPerConnectionRemote = -1;
+    int idleTimeoutSeconds = -1;
+    int poolTimeoutMillis = -1;
+    int maxQueueSize = -1;
+    int heartbeatIntervalSeconds = -1;
+    int coreConnectionsPerHostLocal = -1;
+    int maxConnectionsPerHostLocal = -1;
+    int newConnectionThresholdLocal = -1;
+    int coreConnectionsPerHostRemote = -1;
+    int maxConnectionsPerHostRemote = -1;
+    int newConnectionThresholdRemote = -1;
+}
+
+@Description {value:"Options to configure low-level socket options for the connections kept to the Cassandra hosts"}
+@Field {value:"connectTimeoutMillis: The connection timeout in milliseconds"}
+@Field {value:"readTimeoutMillis: The per-host read timeout in milliseconds"}
+@Field {value:"soLinger: The linger-on-close timeout"}
+@Field {value:"receiveBufferSize: A hint to the size of the underlying buffers for incoming network I/O"}
+@Field {value:"sendBufferSize: A hint to the size of the underlying buffers for outgoing network I/O"}
+public struct SocketOptionsConfiguration {
+    int connectTimeoutMillis = -1;
+    int readTimeoutMillis = -1;
+    int soLinger = -1;
+    int receiveBufferSize = -1;
+    int sendBufferSize = -1;
+
+    // TODO: Driver do not set these by default. It takes the default values of the underlying netty transport.
+    // But if we take the inputs as booleans and if the value set in the bal file is "false", we wouldn't know
+    // if it was set by the user or not. So need to decide how to handle this.
+    // boolean keepAlive;
+    // boolean reuseAddress;
+    // boolean tcpNoDelay;
 }
 
 
-@Description { value:"The Datatype of the parameter"}
-@Field { value:"INT: A 32-bit signed integer"}
-@Field { value:"BIGINT: A 64-bit signed long"}
-@Field { value:"VARINT: Arbitrary precision integer"}
-@Field { value:"FLOAT: A 32-bit IEEE-754 floating point"}
-@Field { value:"DOUBLE: A 64-bit IEEE-754 floating point"}
-@Field { value:"TEXT: UTF-8 encoded string"}
-@Field { value:"BOOLEAN: Boolean value either True or false"}
-@Field { value:"LIST: A collection of one or more ordered elements"}
+
+
+@Description {value:"The Datatype of the parameter"}
+@Field {value:"INT: A 32-bit signed integer"}
+@Field {value:"BIGINT: A 64-bit signed long"}
+@Field {value:"VARINT: Arbitrary precision integer"}
+@Field {value:"FLOAT: A 32-bit IEEE-754 floating point"}
+@Field {value:"DOUBLE: A 64-bit IEEE-754 floating point"}
+@Field {value:"TEXT: UTF-8 encoded string"}
+@Field {value:"BOOLEAN: Boolean value either True or false"}
+@Field {value:"LIST: A collection of one or more ordered elements"}
 public enum Type {
     INT,
     BIGINT,
@@ -42,24 +188,30 @@ public enum Type {
 }
 
 
-@Description { value:"Cassandra client connector."}
-@Param { value:"host:Comma seperate list of addresses of Cassandra nodes which are used to discover the cluster topology" }
-@Param { value:"options: Optional properties for cassandra connection" }
-public connector ClientConnector (string host, ConnectionProperties options) {
+@Description {value:"Cassandra client connector."}
+@Param {value:"host: Comma separated list of addresses of Cassandra nodes which are used to discover the cluster
+topology"}
+@Param {value:"port: The port configured for the Cassandra cluster"}
+@Param {value:"username: The username to connect to a authentication enabled Cassandra cluster"}
+@Param {value:"password: The password to connect to a authentication enabled Cassandra cluster"}
+@Param {value:"options: Optional properties for cassandra connection"}
+public connector ClientConnector (string host, int port, string username, string password, ConnectionProperties
+                                                                                           options) {
 
     map sharedMap = {};
 
     @Description {value:"Select data from cassandra datasource."}
     @Param {value:"query: Query to be executed"}
-    @Param { value:"parameters: Parameter array used with the given query" }
-    @Return { value:"Result set for the given query" }
-    native action select (string query, Parameter[] parameters) (datatable);
+    @Param {value:"parameters: Parameter array used with the given query"}
+    @Param {value:"type:The Type result should be mapped to"}
+    @Return {value:"Result set for the given query"}
+    native action select (string query, Parameter[] parameters, type structType) (table);
 
     @Description {value:"Execute update query on cassandra datasource."}
     @Param {value:"query: Query to be executed"}
-    @Param { value:"parameters: Parameter array used with the given query" }
+    @Param {value:"parameters: Parameter array used with the given query"}
     native action update (string query, Parameter[] parameters);
 
-    @Description { value:"The close action implementation to shutdown the cassandra connections."}
+    @Description {value:"The close action implementation to shutdown the cassandra connections."}
     native action close ();
 }

--- a/component/src/main/java/org/ballerinalang/data/cassandra/CassandraDataSource.java
+++ b/component/src/main/java/org/ballerinalang/data/cassandra/CassandraDataSource.java
@@ -17,14 +17,34 @@
  */
 package org.ballerinalang.data.cassandra;
 
-
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
+import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
+import com.datastax.driver.core.policies.FallthroughRetryPolicy;
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.LoggingRetryPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * {@code CassandraDataSource} util class for Cassandra connector initialization.
@@ -45,32 +65,459 @@ public class CassandraDataSource implements BValue {
         return session;
     }
 
-    public boolean init(String host, BStruct options) {
+    /**
+     * Initializes the Cassandra cluster.
+     *
+     * @param host     Host(s) Cassandra instance(s) reside(s)
+     * @param port     Port for the Cassandra instance(s)
+     * @param username Username if authentication is enabled
+     * @param password Password if authentication is enabled
+     * @param options  BStruct containing available options for cluster connection initialization
+     * @return true if initialization is successful
+     */
+    public boolean init(String host, int port, String username, String password, BStruct options) {
         Cluster.Builder builder = Cluster.builder();
         builder.addContactPoints(host.split(",")).build();
+        if (port != -1) {
+            builder.withPort(port);
+        }
+        populateAuthenticationOptions(builder, username, password);
         if (options != null) {
-            builder = this.createOptions(builder, options);
+            builder = this.populateOptions(builder, options);
         }
         this.cluster = builder.build();
         this.session = this.cluster.connect();
         return true;
     }
 
-    private Cluster.Builder createOptions(Cluster.Builder builder, BStruct options) {
-        boolean sslEnabled = options.getBooleanField(0) != 0;
+    /**
+     * Populates the builder with Cassandra cluster initialization options.
+     *
+     * @param builder Cluster Builder
+     * @param options BStruct containing available options for cluster connection initialization
+     * @return Populated Cluster Builder
+     */
+    private Cluster.Builder populateOptions(Cluster.Builder builder, BStruct options) {
+        BStruct queryOptionsConfig = (BStruct) options.getRefField(ConnectionParam.QUERY_OPTIONS.getIndex());
+        if (queryOptionsConfig != null) {
+            populateQueryOptions(builder, queryOptionsConfig);
+        }
+        BStruct poolingOptionsConfig = (BStruct) options.getRefField(ConnectionParam.POOLING_OPTIONS.getIndex());
+        if (poolingOptionsConfig != null) {
+            populatePoolingOptions(builder, poolingOptionsConfig);
+        }
+        BStruct socketOptionsConfig = (BStruct) options.getRefField(ConnectionParam.SOCKET_OPTIONS.getIndex());
+        if (socketOptionsConfig != null) {
+            populateSocketOptions(builder, socketOptionsConfig);
+        }
+        BStruct protocolOptionsConfig = (BStruct) options.getRefField(ConnectionParam.PROTOCOL_OPTIONS.getIndex());
+        if (protocolOptionsConfig != null) {
+            populateProtocolOptions(builder, protocolOptionsConfig);
+        }
+        String clusterName = options.getStringField(ConnectionParam.CLUSTER_NAME.getIndex());
+        if (!clusterName.isEmpty()) {
+            builder.withClusterName(clusterName);
+        }
+        boolean jmxReportingDisabled = options.getBooleanField(ConnectionParam.WITHOUT_JMX_REPORTING.getIndex()) != 0;
+        if (jmxReportingDisabled) {
+            builder.withoutJMXReporting();
+        }
+        boolean metricsDisabled = options.getBooleanField(ConnectionParam.WITHOUT_METRICS.getIndex()) != 0;
+        if (metricsDisabled) {
+            builder.withoutMetrics();
+        }
+        populateLoadBalancingPolicy(builder, options);
+        populateReconnectionPolicy(builder, options);
+        populateRetryPolicy(builder, options);
+
+        return builder;
+    }
+
+    /**
+     * Populates the Cassnadra RetryPolicy options in the Cluster Builder.
+     *
+     * @param builder Cluster Builder
+     * @param options BStruct containing available options for cluster connection initialization
+     */
+    private void populateRetryPolicy(Cluster.Builder builder, BStruct options) {
+        String retryPolicyString = options.getStringField(ConnectionParam.RETRY_POLICY.getIndex());
+        if (!retryPolicyString.isEmpty()) {
+            RetryPolicy retryPolicy = retrieveRetryPolicy(retryPolicyString);
+            switch (retryPolicy) {
+            case DEFAULT_RETRY_POLICY:
+                builder.withRetryPolicy(DefaultRetryPolicy.INSTANCE);
+                break;
+            case FALLTHROUGH_RETRY_POLICY:
+                builder.withRetryPolicy(FallthroughRetryPolicy.INSTANCE);
+                break;
+            case DOWNGRADING_CONSISTENCY_RETRY_POLICY:
+                builder.withRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE);
+                break;
+            case LOGGING_DEFAULT_RETRY_POLICY:
+                builder.withRetryPolicy(new LoggingRetryPolicy(DefaultRetryPolicy.INSTANCE));
+                break;
+            case LOGGING_FALLTHROUGH_RETRY_POLICY:
+                builder.withRetryPolicy(new LoggingRetryPolicy(FallthroughRetryPolicy.INSTANCE));
+                break;
+            case LOGGING_DOWNGRADING_CONSISTENCY_RETRY_POLICY:
+                builder.withRetryPolicy(new LoggingRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE));
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Support for the retry policy \"" + retryPolicy + "\" is not implemented yet");
+            }
+        }
+    }
+
+    private RetryPolicy retrieveRetryPolicy(String retryPolicy) {
+        try {
+            return RetryPolicy.fromPolicyName(retryPolicy);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaException("\"" + retryPolicy + "\" is not a valid retry policy");
+        }
+    }
+
+    /**
+     * Populates Reconnection Policy options in the Cluster Builder.
+     *
+     * @param builder Cluster Builder
+     * @param options BStruct containing available options for cluster connection initialization
+     */
+    private void populateReconnectionPolicy(Cluster.Builder builder, BStruct options) {
+        String reconnectionPolicyString = options.getStringField(ConnectionParam.RECONNECTION_POLICY.getIndex());
+
+        if (!reconnectionPolicyString.isEmpty()) {
+            ReconnectionPolicy reconnectionPolicy = retrieveReconnectionPolicy(reconnectionPolicyString);
+            switch (reconnectionPolicy) {
+            case CONSTANT_RECONNECTION_POLICY:
+                long constantReconnectionPolicyDelay = options
+                        .getIntField(ConnectionParam.CONSTANT_RECONNECTION_POLICY_DELAY.getIndex());
+                if (constantReconnectionPolicyDelay != -1) {
+                    builder.withReconnectionPolicy(new ConstantReconnectionPolicy(constantReconnectionPolicyDelay));
+                } else {
+                    throw new BallerinaException("constantReconnectionPolicyDelay required for the "
+                            + "initialization of ConstantReconnectionPolicy, has not been set");
+                }
+                break;
+            case EXPONENTIAL_RECONNECTION_POLICY:
+                long exponentialReconnectionPolicyBaseDelay = options
+                        .getIntField(ConnectionParam.EXPONENTIAL_RECONNECTION_POLICY_BASE_DELAY.getIndex());
+                long exponentialReconnectionPolicyMaxDelay = options
+                        .getIntField(ConnectionParam.EXPONENTIAL_RECONNECTION_POLICY_MAX_DELAY.getIndex());
+                if (exponentialReconnectionPolicyBaseDelay != -1 && exponentialReconnectionPolicyMaxDelay != -1) {
+                    builder.withReconnectionPolicy(
+                            new ExponentialReconnectionPolicy(exponentialReconnectionPolicyBaseDelay,
+                                    exponentialReconnectionPolicyMaxDelay));
+                } else {
+                    throw new BallerinaException("exponentialReconnectionPolicyBaseDelay or "
+                            + "exponentialReconnectionPolicyMaxDelay required for the "
+                            + "initialization of ConstantReconnectionPolicy, has not been set");
+                }
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Support for the reconnection policy \"" + reconnectionPolicy + "\" is not implemented yet");
+            }
+        }
+
+    }
+
+    private ReconnectionPolicy retrieveReconnectionPolicy(String reconnectionPolicy) {
+        try {
+            return ReconnectionPolicy.fromPolicyName(reconnectionPolicy);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaException("\"" + reconnectionPolicy + "\"" + " is not a valid reconnection policy");
+        }
+    }
+
+    /**
+     * Populates LoadBalancing Policy options in the Cluster Builder.
+     *
+     * @param builder Cluster Builder
+     * @param options BStruct containing available options for cluster connection initialization
+     */
+    private void populateLoadBalancingPolicy(Cluster.Builder builder, BStruct options) {
+        String dataCenter = options.getStringField(ConnectionParam.DATA_CENTER.getIndex());
+        String loadBalancingPolicyString = options.getStringField(ConnectionParam.LOAD_BALANCING_POLICY.getIndex());
+        boolean allowRemoteDCsForLocalConsistencyLevel =
+                options.getBooleanField(ConnectionParam.ALLOW_REMOTE_DCS_FOR_LOCAL_CONSISTENCY_LEVEL.getIndex()) != 0;
+
+        if (!loadBalancingPolicyString.isEmpty()) {
+            LoadBalancingPolicy loadBalancingPolicy = retrieveLoadBalancingPolicy(loadBalancingPolicyString);
+            switch (loadBalancingPolicy) {
+            case DC_AWARE_ROUND_ROBIN_POLICY:
+                if (dataCenter != null && !dataCenter.isEmpty()) {
+                    if (allowRemoteDCsForLocalConsistencyLevel) {
+                        builder.withLoadBalancingPolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter)
+                                .allowRemoteDCsForLocalConsistencyLevel().build());
+                    } else {
+                        builder.withLoadBalancingPolicy(
+                                DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter).build());
+                    }
+                } else {
+                    if (allowRemoteDCsForLocalConsistencyLevel) {
+                        builder.withLoadBalancingPolicy(
+                                (DCAwareRoundRobinPolicy.builder().allowRemoteDCsForLocalConsistencyLevel().build()));
+                    } else {
+                        builder.withLoadBalancingPolicy((DCAwareRoundRobinPolicy.builder().build()));
+                    }
+                }
+                break;
+            case LATENCY_AWARE_ROUND_ROBIN_POLICY:
+                builder.withLoadBalancingPolicy(LatencyAwarePolicy.builder(new RoundRobinPolicy()).build());
+                break;
+            case ROUND_ROBIN_POLICY:
+                builder.withLoadBalancingPolicy(new RoundRobinPolicy());
+                break;
+            case TOKEN_AWARE_ROUND_ROBIN_POLICY:
+                builder.withLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()));
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Support for the load balancing policy \"" + loadBalancingPolicy + "\" is not implemented yet");
+            }
+        }
+    }
+
+    private LoadBalancingPolicy retrieveLoadBalancingPolicy(String loadBalancingPolicy) {
+        try {
+            return LoadBalancingPolicy.fromPolicyName(loadBalancingPolicy);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaException("\"" + loadBalancingPolicy + "\"" + " is not a valid load balancing policy");
+        }
+    }
+
+    /**
+     * Populates Authentication Options in the Cluster Builder.
+     *
+     * @param builder  Cluster Builder
+     * @param username Provided Username
+     * @param password Provided Password
+     */
+    private void populateAuthenticationOptions(Cluster.Builder builder, String username, String password) {
+        // TODO: Enable functionality for custom authenticators
+        builder.withAuthProvider(new PlainTextAuthProvider(username, password));
+    }
+
+    /**
+     * Populates Query Options in the Cluster Builder.
+     *
+     * @param builder            Cluster Builder
+     * @param queryOptionsConfig BStruct containing available query options for cluster connection initialization
+     */
+    private void populateQueryOptions(Cluster.Builder builder, BStruct queryOptionsConfig) {
+        QueryOptions queryOptions = new QueryOptions();
+
+        String consistencyLevel = queryOptionsConfig.getStringField(QueryOptionsParam.CONSISTENCY_LEVEL.getIndex());
+        String serialConsistencyLevel = queryOptionsConfig
+                .getStringField(QueryOptionsParam.SERIAL_CONSISTENCY_LEVEL.getIndex());
+        boolean defaultIdempotence =
+                queryOptionsConfig.getBooleanField(QueryOptionsParam.DEFAULT_IDEMPOTENCE.getIndex()) != 0;
+        boolean metadataEnabled =
+                queryOptionsConfig.getBooleanField(QueryOptionsParam.METADATA_ENABLED.getIndex()) != 0;
+        boolean reprepareOnUp = queryOptionsConfig.getBooleanField(QueryOptionsParam.REPREPARE_ON_UP.getIndex()) != 0;
+        queryOptions.setReprepareOnUp(reprepareOnUp);
+        boolean prepareOnAllHosts =
+                queryOptionsConfig.getBooleanField(QueryOptionsParam.PREPARE_ON_ALL_HOSTS.getIndex()) != 0;
+        queryOptions.setPrepareOnAllHosts(prepareOnAllHosts);
+        int fetchSize = (int) queryOptionsConfig.getIntField(QueryOptionsParam.FETCH_SIZE.getIndex());
+        int maxPendingRefreshNodeListRequests = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.MAX_PENDING_REFRESH_NODELIST_REQUESTS.getIndex());
+        int maxPendingRefreshNodeRequests = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.MAX_PENDING_REFRESH_NODE_REQUESTS.getIndex());
+        int maxPendingRefreshSchemaRequests = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.MAX_PENDING_REFRESH_SCHEMA_REQUESTS.getIndex());
+        int refreshNodeListIntervalMillis = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.REFRESH_NODELIST_INTERVAL_MILLIS.getIndex());
+        int refreshNodeIntervalMillis = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.REFRESH_NODE_INTERNAL_MILLIS.getIndex());
+        int refreshSchemaIntervalMillis = (int) queryOptionsConfig
+                .getIntField(QueryOptionsParam.REFRESH_SCHEMA_INTERVAL_MILLIS.getIndex());
+
+        if (!consistencyLevel.isEmpty()) {
+            queryOptions.setConsistencyLevel(retrieveConsistencyLevel(consistencyLevel));
+        }
+        if (!serialConsistencyLevel.isEmpty()) {
+            queryOptions.setSerialConsistencyLevel(retrieveSerialConsistencyLevel(serialConsistencyLevel));
+        }
+        queryOptions.setDefaultIdempotence(defaultIdempotence);
+        queryOptions.setMetadataEnabled(metadataEnabled);
+        if (fetchSize != -1) {
+            queryOptions.setFetchSize(fetchSize);
+        }
+        if (maxPendingRefreshNodeListRequests != -1) {
+            queryOptions.setMaxPendingRefreshNodeListRequests(maxPendingRefreshNodeListRequests);
+        }
+        if (maxPendingRefreshNodeRequests != -1) {
+            queryOptions.setMaxPendingRefreshNodeRequests(maxPendingRefreshNodeRequests);
+        }
+        if (maxPendingRefreshSchemaRequests != -1) {
+            queryOptions.setMaxPendingRefreshSchemaRequests(maxPendingRefreshSchemaRequests);
+        }
+        if (refreshNodeListIntervalMillis != -1) {
+            queryOptions.setRefreshNodeIntervalMillis(refreshNodeListIntervalMillis);
+        }
+        if (refreshNodeIntervalMillis != -1) {
+            queryOptions.setRefreshNodeIntervalMillis(refreshNodeIntervalMillis);
+        }
+        if (refreshSchemaIntervalMillis != -1) {
+            queryOptions.setRefreshSchemaIntervalMillis(refreshSchemaIntervalMillis);
+        }
+        builder.withQueryOptions(queryOptions);
+    }
+
+    /**
+     * Populates Pooling Options in the Cluster Builder.
+     *
+     * @param builder              Cluster Builder
+     * @param poolingOptionsConfig BStruct containing available pooling options for cluster connection initialization
+     */
+    private void populatePoolingOptions(Cluster.Builder builder, BStruct poolingOptionsConfig) {
+        PoolingOptions poolingOptions = new PoolingOptions();
+
+        int coreConnectionsPerHostLocal = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.CORE_CONNECTIONS_PER_HOST_LOCAL.getIndex());
+        int maxConnectionsPerHostLocal = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.MAX_CONNECTIONS_PER_HOST_LOCAL.getIndex());
+        int newConnectionThresholdLocal = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.NEW_CONNECTION_THRESHOLD_LOCAL.getIndex());
+        int coreConnectionsPerHostRemote = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.CORE_CONNECTIONS_PER_HOST_REMOTE.getIndex());
+        int maxConnectionsPerHostRemote = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.MAX_CONNECTIONS_PER_HOST_REMOTE.getIndex());
+        int newConnectionThresholdRemote = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.NEW_CONNECTION_THRESHOLD_REMOTE.getIndex());
+        int maxRequestsPerConnectionLocal = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.MAX_REQUESTS_PER_CONNECTION_LOCAL.getIndex());
+        int maxRequestsPerConnectionRemote = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.MAX_REQUESTS_PER_CONNECTION_REMOTE.getIndex());
+        int idleTimeoutSeconds = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.IDLE_TIMEOUT_SECONDS.getIndex());
+        int poolTimeoutMillis = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.POOL_TIMEOUT_MILLIS.getIndex());
+        int maxQueueSize = (int) poolingOptionsConfig.getIntField(PoolingOptionsParam.MAX_QUEUE_SIZE.getIndex());
+        int heartbeatIntervalSeconds = (int) poolingOptionsConfig
+                .getIntField(PoolingOptionsParam.HEART_BEAT_INTERVAL_SECONDS.getIndex());
+
+        if (coreConnectionsPerHostLocal != -1) {
+            poolingOptions.setCoreConnectionsPerHost(HostDistance.LOCAL, coreConnectionsPerHostLocal);
+        }
+        if (coreConnectionsPerHostRemote != -1) {
+            poolingOptions.setCoreConnectionsPerHost(HostDistance.REMOTE, coreConnectionsPerHostRemote);
+        }
+        if (maxConnectionsPerHostLocal != -1) {
+            poolingOptions.setMaxConnectionsPerHost(HostDistance.LOCAL, maxConnectionsPerHostLocal);
+        }
+        if (maxConnectionsPerHostRemote != -1) {
+            poolingOptions.setMaxConnectionsPerHost(HostDistance.REMOTE, maxConnectionsPerHostRemote);
+        }
+        if (newConnectionThresholdLocal != -1) {
+            poolingOptions.setNewConnectionThreshold(HostDistance.LOCAL, newConnectionThresholdLocal);
+        }
+        if (newConnectionThresholdRemote != -1) {
+            poolingOptions.setNewConnectionThreshold(HostDistance.REMOTE, newConnectionThresholdRemote);
+        }
+        if (maxRequestsPerConnectionLocal != -1) {
+            poolingOptions.setMaxRequestsPerConnection(HostDistance.LOCAL, maxRequestsPerConnectionLocal);
+        }
+        if (maxRequestsPerConnectionRemote != -1) {
+            poolingOptions.setMaxRequestsPerConnection(HostDistance.REMOTE, maxRequestsPerConnectionRemote);
+        }
+        if (idleTimeoutSeconds != -1) {
+            poolingOptions.setIdleTimeoutSeconds(idleTimeoutSeconds);
+        }
+        if (poolTimeoutMillis != -1) {
+            poolingOptions.setPoolTimeoutMillis(poolTimeoutMillis);
+        }
+        if (maxQueueSize != -1) {
+            poolingOptions.setMaxQueueSize(maxQueueSize);
+        }
+        if (heartbeatIntervalSeconds != -1) {
+            poolingOptions.setHeartbeatIntervalSeconds(heartbeatIntervalSeconds);
+        }
+
+        builder.withPoolingOptions(poolingOptions);
+    }
+
+    /**
+     * Populates Socket Options in the Cluster Builder.
+     *
+     * @param builder             Cluster Builder
+     * @param socketOptionsConfig BStruct containing available socket options for cluster connection initialization
+     */
+    private void populateSocketOptions(Cluster.Builder builder, BStruct socketOptionsConfig) {
+        SocketOptions socketOptions = new SocketOptions();
+
+        int connectTimeoutMillis = (int) socketOptionsConfig
+                .getIntField(SocketOptionsParam.CONNECT_TIMEOUT_MILLIS.getIndex());
+        int readTimeoutMillis = (int) socketOptionsConfig
+                .getIntField(SocketOptionsParam.READ_TIMEOUT_MILLIS.getIndex());
+        int soLinger = (int) socketOptionsConfig.getIntField(SocketOptionsParam.SO_LINGER.getIndex());
+        int receiveBufferSize = (int) socketOptionsConfig
+                .getIntField(SocketOptionsParam.RECEIVE_BUFFER_SIZE.getIndex());
+        int sendBufferSize = (int) socketOptionsConfig.getIntField(SocketOptionsParam.SEND_BUFFER_SIZE.getIndex());
+
+        if (connectTimeoutMillis != -1) {
+            socketOptions.setConnectTimeoutMillis(connectTimeoutMillis);
+        }
+        if (readTimeoutMillis != -1) {
+            socketOptions.setReadTimeoutMillis(readTimeoutMillis);
+        }
+        if (soLinger != -1) {
+            socketOptions.setSoLinger(soLinger);
+        }
+        if (receiveBufferSize != -1) {
+            socketOptions.setReceiveBufferSize(receiveBufferSize);
+        }
+        if (sendBufferSize != -1) {
+            socketOptions.setSendBufferSize(sendBufferSize);
+        }
+
+    /* TODO: Driver does not set these by default. It takes the default values of the underlying netty transport.
+        But if we take the inputs as booleans and if the value set in the bal file is "false", we wouldn't know
+        if it was set by the user or not. So need to decide how to handle this.
+        boolean keepAlive = socketOptionsConfig.getBooleanField(SocketOptionsParam.KEEP_ALIVE.getIndex()) != 0;
+        boolean reuseAddress = socketOptionsConfig.getBooleanField(SocketOptionsParam.REUSE_ADDRESS.getIndex()) != 0;
+        boolean tcpNoDelay = socketOptionsConfig.getBooleanField(SocketOptionsParam.TCP_NO_DELAY.getIndex()) != 0;
+
+        socketOptions.setKeepAlive(keepAlive);
+        socketOptions.setReuseAddress(reuseAddress);
+        socketOptions.setTcpNoDelay(tcpNoDelay);
+    */
+        builder.withSocketOptions(socketOptions);
+    }
+
+    /**
+     * Populates Protocol Options in the Cluster Builder.
+     *
+     * @param builder               Cluster Builder
+     * @param protocolOptionsConfig BStruct containing available protocol options for cluster connection initialization
+     */
+    private void populateProtocolOptions(Cluster.Builder builder, BStruct protocolOptionsConfig) {
+        boolean sslEnabled = protocolOptionsConfig.getBooleanField(ProtocolOptionsParam.SSL_ENABLED.getIndex()) != 0;
+        boolean noCompact = protocolOptionsConfig.getBooleanField(ProtocolOptionsParam.NO_COMPACT.getIndex()) != 0;
+
+        int maxSchemaAgreementWaitSeconds = (int) protocolOptionsConfig
+                .getIntField(ProtocolOptionsParam.MAX_SCHEMA_AGREEMENT_WAIT_SECONDS.getIndex());
+        String compression = protocolOptionsConfig.getStringField(ProtocolOptionsParam.COMPRESSION.getIndex());
+        String initialProtocolVersion = protocolOptionsConfig
+                .getStringField(ProtocolOptionsParam.INITIAL_PROTOCOL_VERSION.getIndex());
+
         if (sslEnabled) {
             builder = builder.withSSL();
         }
-        QueryOptions queryOpts = new QueryOptions();
-        String consistencyLevel = options.getStringField(0);
-        if (!consistencyLevel.isEmpty()) {
-            queryOpts.setConsistencyLevel(ConsistencyLevel.valueOf(consistencyLevel));
+        if (noCompact) {
+            builder.withNoCompact();
         }
-        int fetchSize = (int) options.getIntField(0);
-        if (fetchSize != -1) {
-            queryOpts.setFetchSize(fetchSize);
+        if (maxSchemaAgreementWaitSeconds != -1) {
+            builder.withMaxSchemaAgreementWaitSeconds(maxSchemaAgreementWaitSeconds);
         }
-        return builder.withQueryOptions(queryOpts);
+        if (!compression.isEmpty()) {
+            builder.withCompression(retrieveCompression(compression));
+        }
+        if (!initialProtocolVersion.isEmpty()) {
+            builder.withProtocolVersion(retrieveProtocolVersion(initialProtocolVersion));
+        }
     }
 
     @Override
@@ -86,5 +533,257 @@ public class CassandraDataSource implements BValue {
     @Override
     public BValue copy() {
         return null;
+    }
+
+    private ProtocolVersion retrieveProtocolVersion(String protocolVersion) {
+        try {
+            return ProtocolVersion.valueOf(protocolVersion);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaException("\"" + protocolVersion + "\" is not a valid protocol version");
+        }
+    }
+
+    private ProtocolOptions.Compression retrieveCompression(String compression) {
+        try {
+            return ProtocolOptions.Compression.valueOf(compression);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaException("\"" + compression + "\" is not a valid compression type");
+        }
+    }
+
+    private ConsistencyLevel retrieveSerialConsistencyLevel(String consistencyLevel) {
+        try {
+            ConsistencyLevel serialConsistencyLevel = ConsistencyLevel.valueOf(consistencyLevel);
+            if (serialConsistencyLevel.isSerial()) {
+                return serialConsistencyLevel;
+            } else {
+                throw new BallerinaException("\"" + consistencyLevel + "\" is not a valid serial consistency level");
+            }
+        } catch (DriverInternalError e) {
+            throw new BallerinaException("\"" + consistencyLevel + "\" is not a valid serial consistency level");
+        }
+    }
+
+    private ConsistencyLevel retrieveConsistencyLevel(String consistencyLevel) {
+        try {
+            return ConsistencyLevel.valueOf(consistencyLevel);
+        } catch (DriverInternalError e) {
+            throw new BallerinaException("\"" + consistencyLevel + "\" is not a valid consistency level");
+        }
+    }
+
+    private enum SocketOptionsParam {
+        // int params
+        CONNECT_TIMEOUT_MILLIS(0), READ_TIMEOUT_MILLIS(1), SO_LINGER(2), RECEIVE_BUFFER_SIZE(3), SEND_BUFFER_SIZE(4),
+
+        // boolean params
+        KEEP_ALIVE(0), REUSE_ADDRESS(1), TCP_NO_DELAY(2);
+
+        private int index;
+
+        SocketOptionsParam(int index) {
+            this.index = index;
+        }
+
+        private int getIndex() {
+            return index;
+        }
+    }
+
+    private enum PoolingOptionsParam {
+        // int params
+        MAX_REQUESTS_PER_CONNECTION_LOCAL(0), MAX_REQUESTS_PER_CONNECTION_REMOTE(1), IDLE_TIMEOUT_SECONDS(
+                2), POOL_TIMEOUT_MILLIS(3), MAX_QUEUE_SIZE(4), HEART_BEAT_INTERVAL_SECONDS(
+                5), CORE_CONNECTIONS_PER_HOST_LOCAL(6), MAX_CONNECTIONS_PER_HOST_LOCAL(
+                7), NEW_CONNECTION_THRESHOLD_LOCAL(8), CORE_CONNECTIONS_PER_HOST_REMOTE(
+                9), MAX_CONNECTIONS_PER_HOST_REMOTE(10), NEW_CONNECTION_THRESHOLD_REMOTE(11);
+
+        private int index;
+
+        PoolingOptionsParam(int index) {
+            this.index = index;
+        }
+
+        private int getIndex() {
+            return index;
+        }
+    }
+
+    private enum QueryOptionsParam {
+        // string params
+        CONSISTENCY_LEVEL(0), SERIAL_CONSISTENCY_LEVEL(1),
+
+        // boolean params
+        DEFAULT_IDEMPOTENCE(0), METADATA_ENABLED(1), REPREPARE_ON_UP(2), PREPARE_ON_ALL_HOSTS(3),
+
+        // int params
+        FETCH_SIZE(0), MAX_PENDING_REFRESH_NODELIST_REQUESTS(1), MAX_PENDING_REFRESH_NODE_REQUESTS(
+                2), MAX_PENDING_REFRESH_SCHEMA_REQUESTS(3), REFRESH_NODELIST_INTERVAL_MILLIS(
+                4), REFRESH_NODE_INTERNAL_MILLIS(5), REFRESH_SCHEMA_INTERVAL_MILLIS(6);
+
+        private int index;
+
+        QueryOptionsParam(int index) {
+            this.index = index;
+        }
+
+        private int getIndex() {
+            return index;
+        }
+    }
+
+    private enum ProtocolOptionsParam {
+        // boolean params
+        SSL_ENABLED(0), NO_COMPACT(1),
+
+        // int params
+        MAX_SCHEMA_AGREEMENT_WAIT_SECONDS(0),
+
+        // string params
+        INITIAL_PROTOCOL_VERSION(0), COMPRESSION(1);
+
+        private int index;
+
+        ProtocolOptionsParam(int index) {
+            this.index = index;
+        }
+
+        private int getIndex() {
+            return index;
+        }
+    }
+
+    private enum ConnectionParam {
+        // string params
+        CLUSTER_NAME(0), LOAD_BALANCING_POLICY(1), RECONNECTION_POLICY(2), RETRY_POLICY(3), DATA_CENTER(4),
+
+        // boolean params
+        WITHOUT_METRICS(0), WITHOUT_JMX_REPORTING(1), ALLOW_REMOTE_DCS_FOR_LOCAL_CONSISTENCY_LEVEL(2),
+
+        // int params
+        CONSTANT_RECONNECTION_POLICY_DELAY(0), EXPONENTIAL_RECONNECTION_POLICY_BASE_DELAY(
+                1), EXPONENTIAL_RECONNECTION_POLICY_MAX_DELAY(2),
+
+        // ref params
+        QUERY_OPTIONS(0), POOLING_OPTIONS(1), SOCKET_OPTIONS(2), PROTOCOL_OPTIONS(3);
+
+        private int index;
+
+        ConnectionParam(int index) {
+            this.index = index;
+        }
+
+        private int getIndex() {
+            return index;
+        }
+
+    }
+
+    private enum LoadBalancingPolicy {
+        DC_AWARE_ROUND_ROBIN_POLICY("DCAwareRoundRobinPolicy"), LATENCY_AWARE_ROUND_ROBIN_POLICY(
+                "LatencyAwarePolicy"), ROUND_ROBIN_POLICY("RoundRobinPolicy"), TOKEN_AWARE_ROUND_ROBIN_POLICY(
+                "TokenAwarePolicy");
+        // TODO: Add support for HostFilterPolicy.
+        // TODO: Add support for ErrorAwarePolicy which is still(datastax driver 3.4.0) in beta mode
+
+        private String loadBalancingPolicy;
+
+        private static final Map<String, LoadBalancingPolicy> policyMap = new HashMap<>();
+
+        LoadBalancingPolicy(String loadBalancingPolicy) {
+            this.loadBalancingPolicy = loadBalancingPolicy;
+        }
+
+        static {
+            LoadBalancingPolicy[] policies = values();
+            for (LoadBalancingPolicy policy : policies) {
+                policyMap.put(policy.getPolicyName(), policy);
+            }
+        }
+
+        public static LoadBalancingPolicy fromPolicyName(String policyName) {
+            LoadBalancingPolicy policy = policyMap.get(policyName);
+            if (policy == null) {
+                throw new IllegalArgumentException("Unsupported Load Balancing policy: " + policyName);
+            } else {
+                return policy;
+            }
+        }
+
+        private String getPolicyName() {
+            return this.loadBalancingPolicy;
+        }
+
+    }
+
+    private enum ReconnectionPolicy {
+        CONSTANT_RECONNECTION_POLICY("ConstantReconnectionPolicy"), EXPONENTIAL_RECONNECTION_POLICY(
+                "ExponentialReconnectionPolicy");
+
+        private String reconnectionPolicy;
+
+        private static final Map<String, ReconnectionPolicy> policyMap = new HashMap<>();
+
+        ReconnectionPolicy(String reconnectionPolicy) {
+            this.reconnectionPolicy = reconnectionPolicy;
+        }
+
+        static {
+            ReconnectionPolicy[] policies = values();
+            for (ReconnectionPolicy policy : policies) {
+                policyMap.put(policy.getPolicyName(), policy);
+            }
+        }
+
+        public static ReconnectionPolicy fromPolicyName(String policyName) {
+            ReconnectionPolicy policy = policyMap.get(policyName);
+            if (policy == null) {
+                throw new IllegalArgumentException("Unsupported Reconnection policy: " + policyName);
+            } else {
+                return policy;
+            }
+        }
+
+        private String getPolicyName() {
+            return this.reconnectionPolicy;
+        }
+
+    }
+
+    private enum RetryPolicy {
+        DEFAULT_RETRY_POLICY("DefaultRetryPolicy"), DOWNGRADING_CONSISTENCY_RETRY_POLICY(
+                "DowngradingConsistencyRetryPolicy"), FALLTHROUGH_RETRY_POLICY(
+                "FallthroughRetryPolicy"), LOGGING_DEFAULT_RETRY_POLICY(
+                "LoggingDefaultRetryPolicy"), LOGGING_DOWNGRADING_CONSISTENCY_RETRY_POLICY(
+                "LoggingDowngradingConsistencyRetryPolicy"), LOGGING_FALLTHROUGH_RETRY_POLICY(
+                "LoggingFallthroughRetryPolicy");
+
+        private String retryPolicy;
+
+        private static final Map<String, RetryPolicy> policyMap = new HashMap<>();
+
+        RetryPolicy(String retryPolicy) {
+            this.retryPolicy = retryPolicy;
+        }
+
+        private String getPolicyName() {
+            return this.retryPolicy;
+        }
+
+        static {
+            RetryPolicy[] policies = values();
+            for (RetryPolicy policy : policies) {
+                policyMap.put(policy.getPolicyName(), policy);
+            }
+        }
+
+        public static RetryPolicy fromPolicyName(String policyName) {
+            RetryPolicy mechanism = policyMap.get(policyName);
+            if (mechanism == null) {
+                throw new IllegalArgumentException("Unsupported Retry policy: " + policyName);
+            } else {
+                return mechanism;
+            }
+        }
     }
 }

--- a/component/src/main/java/org/ballerinalang/data/cassandra/actions/AbstractCassandraAction.java
+++ b/component/src/main/java/org/ballerinalang/data/cassandra/actions/AbstractCassandraAction.java
@@ -30,6 +30,7 @@ import org.ballerinalang.data.cassandra.CassandraDataSource;
 import org.ballerinalang.data.cassandra.Constants;
 import org.ballerinalang.model.ColumnDefinition;
 import org.ballerinalang.model.types.BArrayType;
+import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BBlob;
@@ -37,7 +38,6 @@ import org.ballerinalang.model.values.BBlobArray;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BBooleanArray;
 import org.ballerinalang.model.values.BConnector;
-import org.ballerinalang.model.values.BDataTable;
 import org.ballerinalang.model.values.BEnumerator;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BFloatArray;
@@ -49,6 +49,8 @@ import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BTable;
+import org.ballerinalang.model.values.BTypeValue;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.nativeimpl.actions.ClientConnectorFuture;
 import org.ballerinalang.natives.exceptions.ArgumentOutOfRangeException;
@@ -70,17 +72,18 @@ public abstract class AbstractCassandraAction extends AbstractNativeAction {
     @Override
     public BValue getRefArgument(Context context, int index) {
         if (index > -1) {
-            return context.getControlStackNew().getCurrentFrame().getRefLocalVars()[index];
+            return context.getControlStack().getCurrentFrame().getRefRegs()[index];
         }
         throw new ArgumentOutOfRangeException(index);
     }
 
-    public BDataTable executeSelect(CassandraDataSource dataSource, String query, BRefValueArray parameters) {
+    public BTable executeSelect(CassandraDataSource dataSource, String query, BRefValueArray parameters, BStructType
+            type) {
         String processedQuery = createProcessedQueryString(query, parameters);
         PreparedStatement preparedStatement = dataSource.getSession().prepare(processedQuery);
         BoundStatement stmt = createBoundStatement(preparedStatement, parameters);
         ResultSet rs = dataSource.getSession().execute(stmt);
-        return new BDataTable(new CassandraDataIterator(rs, this.getColumnDefinitions(rs)));
+        return new BTable(new CassandraDataIterator(rs, this.getColumnDefinitions(rs), type));
     }
 
     public void executeUpdate(CassandraDataSource dataSource, String query, BRefValueArray parameters) {
@@ -115,13 +118,22 @@ public abstract class AbstractCassandraAction extends AbstractNativeAction {
         return datasource;
     }
 
+    BStructType getStructType(Context context) {
+        BStructType structType = null;
+        BTypeValue type = (BTypeValue) getRefArgument(context, 2);
+        if (type != null) {
+            structType = (BStructType) type.value();
+        }
+        return structType;
+    }
+
     private List<ColumnDefinition> getColumnDefinitions(ResultSet rs) {
         List<ColumnDefinition> columnDefs = new ArrayList<ColumnDefinition>();
         Set<String> columnNames = new HashSet<>();
         for (ColumnDefinitions.Definition def : rs.getColumnDefinitions().asList()) {
             String colName = def.getName();
             if (columnNames.contains(colName)) {
-                String tableName = def.getTable().toUpperCase();
+                String tableName = def.getTable().toUpperCase(Locale.ENGLISH);
                 colName = tableName + "." + colName;
             }
             columnDefs.add(new ColumnDefinition(colName, this.convert(def.getType())));
@@ -242,7 +254,7 @@ public abstract class AbstractCassandraAction extends AbstractNativeAction {
     }
 
     private BoundStatement createBoundStatement(PreparedStatement stmt, BRefValueArray params) {
-        ArrayList<Object> dataList = new ArrayList<Object>();
+        ArrayList<Object> dataList = new ArrayList<>();
         BoundStatement boundStmt = stmt.bind();
         if (params == null) {
             return boundStmt;
@@ -259,7 +271,7 @@ public abstract class AbstractCassandraAction extends AbstractNativeAction {
                     int arrayLength = (int) ((BNewArray) value).size();
                     int typeTag = ((BArrayType) value.getType()).getElementType().getTag();
                     for (int i = 0; i < arrayLength; i++) {
-                        Object paramValue;
+                        BValue paramValue;
                         switch (typeTag) {
                         case TypeTags.INT_TAG:
                             paramValue = new BInteger(((BIntArray) value).get(i));
@@ -279,7 +291,7 @@ public abstract class AbstractCassandraAction extends AbstractNativeAction {
                         default:
                             throw new BallerinaException("unsupported array type for parameter index " + index);
                         }
-                        dataList.add(paramValue);
+                        bindValue(dataList, paramValue, cqlType);
                     }
                 } else {
                     bindValue(dataList, value, cqlType);

--- a/component/src/main/java/org/ballerinalang/data/cassandra/actions/Init.java
+++ b/component/src/main/java/org/ballerinalang/data/cassandra/actions/Init.java
@@ -46,11 +46,14 @@ public class Init extends AbstractCassandraAction {
     public ConnectorFuture execute(Context context) {
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
         String host = bConnector.getStringField(0);
+        int port = (int) bConnector.getIntField(0);
+        String username = bConnector.getStringField(1);
+        String password = bConnector.getStringField(2);
         BStruct optionStruct = (BStruct) bConnector.getRefField(0);
         BMap sharedMap = (BMap) bConnector.getRefField(1);
         if (sharedMap.get(new BString(Constants.DATASOURCE_KEY)) == null) {
             CassandraDataSource datasource = new CassandraDataSource();
-            datasource.init(host, optionStruct);
+            datasource.init(host, port, username, password, optionStruct);
             sharedMap.put(new BString(Constants.DATASOURCE_KEY), datasource);
         }
         return getConnectorFuture();

--- a/component/src/main/java/org/ballerinalang/data/cassandra/actions/Select.java
+++ b/component/src/main/java/org/ballerinalang/data/cassandra/actions/Select.java
@@ -21,10 +21,11 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.connector.api.ConnectorFuture;
 import org.ballerinalang.data.cassandra.CassandraDataSource;
 import org.ballerinalang.data.cassandra.Constants;
+import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BConnector;
-import org.ballerinalang.model.values.BDataTable;
 import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BTable;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
@@ -42,7 +43,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
                 @Argument(name = "parameters", type = TypeKind.ARRAY, elementType = TypeKind.STRUCT,
                           structType = "Parameter")
         },
-        returnType = { @ReturnType(type = TypeKind.DATATABLE) }
+        returnType = { @ReturnType(type = TypeKind.TABLE) }
 )
 public class Select extends AbstractCassandraAction {
 
@@ -51,9 +52,10 @@ public class Select extends AbstractCassandraAction {
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
         String query = getStringArgument(context, 0);
         BRefValueArray parameters = (BRefValueArray) getRefArgument(context, 1);
+        BStructType structType = getStructType(context);
         CassandraDataSource dataSource = getDataSource(bConnector);
-        BDataTable dataTable = executeSelect(dataSource, query, parameters);
-        context.getControlStackNew().getCurrentFrame().returnValues[0] = dataTable;
+        BTable dataTable = executeSelect(dataSource, query, parameters, structType);
+        context.getControlStack().getCurrentFrame().returnValues[0] = dataTable;
         return getConnectorFuture();
     }
 }

--- a/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraActionsTest.java
+++ b/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraActionsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.data.cassandra.actions;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * This class contains test cases for SELECT, UPDATE actions.
+ */
+public class CassandraActionsTest extends CassandraBaseTest {
+    private static CompileResult result;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() throws Exception {
+        result = BCompileUtil.compile("samples/cassandra-actions-test.bal");
+        populateDatabase();
+    }
+
+    public void populateDatabase() {
+        PreparedStatement keySpaceCreateStmt = session.prepare(
+                "CREATE KEYSPACE peopleinfoks  WITH replication = {'class':'SimpleStrategy', 'replication_factor' : "
+                        + "1}");
+        session.execute(keySpaceCreateStmt.bind());
+        PreparedStatement createTableStmt = session.prepare("CREATE TABLE peopleinfoks.person(id int, name "
+                + "text,salary float,income double, married boolean, PRIMARY KEY (id, name, salary, income, married))");
+        session.execute(createTableStmt.bind());
+        PreparedStatement insertStmt = session.prepare(
+                "insert into peopleinfoks.person (id, name, salary, income, married) values (1, 'Jack', 100.2, "
+                        + "10000.5, true)");
+        session.execute(insertStmt.bind());
+
+    }
+
+    @Test(description = "This method tests Cassandra key space creation")
+    public void testKeySpaceCreation() throws Exception {
+        BRunUtil.invoke(result, "testKeySpaceCreation");
+        Session session = null;
+        try {
+            session = cluster.connect("dummyks");
+            Assert.assertEquals(session.getLoggedKeyspace(), "dummyks");
+        } catch (InvalidQueryException e) {
+            Assert.fail("KeySpace generation might have failed");
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    @Test(description = "This method tests table creation in a Cassandra database")
+    public void testTableCreation() throws Exception {
+        BRunUtil.invoke(result, "testTableCreation");
+        PreparedStatement selectStmt = session.prepare("select * from peopleinfoks.student");
+        ResultSet resultSet = session.execute(selectStmt.bind());
+        List<Row> resultList = resultSet.all();
+        Assert.assertEquals(resultList.size(), 0, "An empty result set should have been retrieved");
+    }
+
+    @Test(description = "This method tests insertion to Cassandra database")
+    public void testInsert() {
+        BRunUtil.invoke(result, "testInsert");
+        PreparedStatement selectStmt = session.prepare("select * from peopleinfoks.person where id = 2");
+        ResultSet resultSet = session.execute(selectStmt.bind());
+        List<Row> resultList = resultSet.all();
+        boolean found = false;
+        for (Row row : resultList) {
+            if (row.get("id", Integer.class) == 2 && "Tim".equals(row.get("name", String.class))
+                    && Float.compare(row.get("salary", Float.class), 100.5f) == 0
+                    && Double.compare(row.get("income", Double.class), 1000.5) == 0 && row
+                    .get("married", Boolean.class)) {
+                found = true;
+            }
+        }
+        Assert.assertTrue(found, "The data might not have been inserted");
+    }
+
+    @Test(description = "This method tests selection from Cassandra database")
+    public void testSelect() {
+        BValue[] results = BRunUtil.invoke(result, "testSelect");
+        long id = ((BInteger) results[0]).intValue();
+        String name = results[1].stringValue();
+        float salary = (float) ((BFloat) results[2]).floatValue();
+        Assert.assertTrue(id == 1 && "Jack".equals(name) && Float.compare(salary, 100.2f) == 0,
+                "Retrieved data is incorrect");
+    }
+
+    @Test(description = "This method tests select action with parameter arrays")
+    public void testSelectWithParamArray() {
+        BValue[] results = BRunUtil.invoke(result, "testSelectWithParamArray");
+        long id = ((BInteger) results[0]).intValue();
+        String name = results[1].stringValue();
+        float salary = (float) ((BFloat) results[2]).floatValue();
+        boolean married = ((BBoolean) results[3]).booleanValue();
+        Assert.assertTrue(id == 1 && "Jack".equals(name) && Float.compare(salary, 100.2f) == 0 && married,
+                "Retrieved data is incorrect");
+    }
+
+}

--- a/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraBaseTest.java
+++ b/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraBaseTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.data.cassandra.actions;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.thrift.transport.TTransportException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+
+import java.io.IOException;
+
+/**
+ * This class contains methods which are responsible for starting/cleaning up embedded cassandra server and creating
+ * a session for assertion purposes.
+ */
+public class CassandraBaseTest {
+
+    static Cluster cluster;
+    static Session session;
+
+    private static final int CASSANDRA_PORT = 9142;
+    private static final String CASSANDRA_HOST = "localhost";
+
+    @BeforeSuite(alwaysRun = true)
+    public static void startAndSetupCassandraServer()
+            throws InterruptedException, TTransportException, ConfigurationException, IOException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra.yaml");
+
+        Cluster.Builder builder = Cluster.builder();
+        builder.addContactPoints(CASSANDRA_HOST).build();
+        cluster = builder.withPort(CASSANDRA_PORT).build();
+        session = cluster.connect();
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public static void stopCassandraServer() {
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    }
+}

--- a/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraConnectionInitTest.java
+++ b/component/src/test/java/org/ballerinalang/data/cassandra/actions/CassandraConnectionInitTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.data.cassandra.actions;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class CassandraConnectionInitTest extends CassandraBaseTest {
+    private static CompileResult result;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() throws Exception {
+        result = BCompileUtil.compile("samples/cassandra-connection-init-test.bal");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with a Load Balancing Policy")
+    public void testConnectionInitWithLBPolicy() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithLBPolicy", "lbtestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with a Retry Policy")
+    public void testConnectionInitWithRetryPolicy() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithRetryPolicy", "retrytestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with a Reconnection Policy")
+    public void testConnectionInitWithReconnectionPolicy() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithReconnectionPolicy", "reconnectiontestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with Pooling Options")
+    public void testConnectionInitWithPoolingOptions() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithPoolingOptions", "poolingoptionstestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with Socket Options")
+    public void testConnectionInitWithSocketOptions() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithSocketOptions", "socketoptionstestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with Query Options")
+    public void testConnectionInitWithQueryOptions() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithQueryOptions", "queryoptionstestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with Protocol Options")
+    public void testConnectionInitWithProtocolOptions() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithProtocolOptions", "protocoloptionstestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with additional connection parameters")
+    public void testConnectionInitWithAdditionalConParams() throws Exception {
+        testConnectionInitByKeySpaceGeneration("testConnectionInitWithAdditionalConnectionParams",
+                "conparamtestkeyspace");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with an invalid Load Balancing Policy",
+          expectedExceptions = { BLangRuntimeException.class })
+    public void testConnectionInitWithInvalidLBPolicy() throws Exception {
+        BRunUtil.invoke(result, "testConnectionInitWithInvalidLBPolicy");
+        Assert.fail("BLangRuntimeException should have been thrown by this point");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with an invalid Retry Policy",
+          expectedExceptions = { BLangRuntimeException.class })
+    public void testConnectionInitWithInvalidRetryPolicy() throws Exception {
+        BRunUtil.invoke(result, "testConnectionInitWithInvalidRetryPolicy");
+        Assert.fail("BLangRuntimeException should have been thrown by this point");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with an invalid Reconnection Policy",
+          expectedExceptions = { BLangRuntimeException.class })
+    public void testConnectionInitWithInvalidReconnectionPolicy() throws Exception {
+        BRunUtil.invoke(result, "testConnectionInitWithInvalidReconnectionPolicy");
+        Assert.fail("BLangRuntimeException should have been thrown by this point");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with an invalid Consistency Level",
+          expectedExceptions = { BLangRuntimeException.class })
+    public void testConnectionInitWithInvalidConsistencyLevel() throws Exception {
+        BRunUtil.invoke(result, "testConnectionInitWithInvalidConsistencyLevel");
+        Assert.fail("BLangRuntimeException should have been thrown by this point");
+    }
+
+    @Test(description = "This method tests Cassandra Connection Inilialization with an invalid Serial Consistency "
+            + "Level", expectedExceptions = { BLangRuntimeException.class })
+    public void testConnectionInitWithInvalidSerialConsistencyLevel() throws Exception {
+        BRunUtil.invoke(result, "testConnectionInitWithInvalidSerialConsistencyLevel");
+        Assert.fail("BLangRuntimeException should have been thrown by this point");
+    }
+
+    private void testConnectionInitByKeySpaceGeneration(String function, String keyspace) {
+        BRunUtil.invoke(result, function);
+        Session session = null;
+        try {
+            session = cluster.connect(keyspace);
+            Assert.assertEquals(session.getLoggedKeyspace(), keyspace);
+        } catch (InvalidQueryException e) {
+            Assert.fail("KeySpace generation might have failed");
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+}

--- a/component/src/test/resources/cassandra.yaml
+++ b/component/src/test/resources/cassandra.yaml
@@ -1,0 +1,607 @@
+#
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# You should always specify InitialToken when setting up a production
+# cluster for the first time, and often when adding capacity later.
+# The principle is that each node should be given an equal slice of
+# the token ring; see http://wiki.apache.org/cassandra/Operations
+# for more details.
+#
+# If blank, Cassandra will request a token bisecting the range of
+# the heaviest-loaded existing node.  If there is no load information
+# available, such as is the case with a new cluster, it will pick
+# a random token, which will lead to hot spots.
+#initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+hints_directory: target/embeddedCassandra/hints
+
+# The following setting populates the page cache on memtable flush and compaction
+# WARNING: Enable this setting only when the whole node's data fits in memory.
+# Defaults to: false
+# populate_io_cache_on_flush: false
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+#authenticator: PasswordAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+
+# The partitioner is responsible for distributing rows (by key) across
+# nodes in the cluster.  Any IPartitioner may be used, including your/m
+# own as long as it is on the classpath.  Out of the box, Cassandra
+# provides org.apache.cassandra.dht.{Murmur3Partitioner, RandomPartitioner
+# ByteOrderedPartitioner, OrderPreservingPartitioner (deprecated)}.
+#
+# - RandomPartitioner distributes rows across the cluster evenly by md5.
+#   This is the default prior to 1.2 and is retained for compatibility.
+# - Murmur3Partitioner is similar to RandomPartioner but uses Murmur3_128
+#   Hash Function instead of md5.  When in doubt, this is the best option.
+# - ByteOrderedPartitioner orders rows lexically by key bytes.  BOP allows
+#   scanning rows in key order, but the ordering can generate hot spots
+#   for sequential insertion workloads.
+# - OrderPreservingPartitioner is an obsolete form of BOP, that stores
+# - keys in a less-efficient format and only works with keys that are
+#   UTF8-encoded Strings.
+# - CollatingOPP collates according to EN,US rules rather than lexical byte
+#   ordering.  Use this as an example if you need custom collation.
+#
+# See http://wiki.apache.org/cassandra/Operations for more on
+# partitioners and token selection.
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# directories where Cassandra should store data on disk.
+data_file_directories:
+    - target/embeddedCassandra/data
+
+# commit log
+commitlog_directory: target/embeddedCassandra/commitlog
+
+cdc_raw_directory: target/embeddedCassandra/cdc
+
+# policy for data disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must store the whole values of
+# its rows, so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# safe the keys cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# safe the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# saved caches
+saved_caches_directory: target/embeddedCassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch."
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "127.0.0.1"
+
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+
+# Total memory to use for memtables.  Cassandra will flush the largest
+# memtable when this much memory is used.
+# If omitted, Cassandra will set it to 1/3 of the heap.
+# memtable_total_space_in_mb: 2048
+
+# Total space to use for commitlogs.
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.
+# commitlog_total_space_in_mb: 4096
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked. If you have a large heap and many data directories,
+# you can increase this value for better flush performance.
+# By default this will be set to the amount of data directories defined.
+#memtable_flush_writers: 1
+
+# the number of full memtables to allow pending flush, that is,
+# waiting for a writer thread.  At a minimum, this should be set to
+# the maximum number of secondary indexes created on a single CF.
+#memtable_flush_queue_size: 4
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSD:s; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+storage_port: 7010
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 7011
+
+# Address to bind to and tell other Cassandra nodes to connect to. You
+# _must_ change this if you want multiple nodes to be able to
+# communicate!
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing *if* the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting this to 0.0.0.0 is always wrong.
+listen_address: 127.0.0.1
+
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+native_transport_port: 9142
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# The address to bind the Thrift RPC service to -- clients connect
+# here. Unlike ListenAddress above, you *can* specify 0.0.0.0 here if
+# you want Thrift to listen on all interfaces.
+#
+# Leaving this blank has the same effect it does for ListenAddress,
+# (i.e. it will be based on the configured hostname of the node).
+rpc_address: localhost
+# port for Thrift to listen for clients on
+rpc_port: 9171
+
+# enable or disable keepalive on rpc connections
+rpc_keepalive: true
+
+# Cassandra provides three options for the RPC Server:
+#
+# sync  -> One connection per thread in the rpc pool (see below).
+#          For a very large number of clients, memory will be your limiting
+#          factor; on a 64 bit JVM, 128KB is the minimum stack size per thread.
+#          Connection pooling is very, very strongly recommended.
+#
+# async -> Nonblocking server implementation with one thread to serve
+#          rpc connections.  This is not recommended for high throughput use
+#          cases. Async has been tested to be about 50% slower than sync
+#          or hsha and is deprecated: it will be removed in the next major release.
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." The rpc thread pool
+#          (see below) is used to manage requests, but the threads are multiplexed
+#          across the different clients.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max|thread to set request pool size.
+# You would primarily set max for the sync server to safeguard against
+# misbehaved clients; if you do hit the max, Cassandra will block until one
+# disconnects before accepting more.  The defaults for sync are min of 16 and max
+# unlimited.
+#
+# For the Hsha server, the min and max both default to quadruple the number of
+# CPU cores.
+#
+# This configuration is ignored by the async server.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum field length).
+# 0 disables TFramedTransport in favor of TSocket. This option
+# is deprecated; we strongly recommend using Framed mode.
+thrift_framed_transport_size_in_mb: 15
+
+# The max length of a thrift message, including all fields and
+# internal thrift overhead.
+thrift_max_message_length_in_mb: 16
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# Keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# Add column indexes to a row after its contents reach this size.
+# Increase if your column values are large, or if you have a very large
+# number of columns.  The competing causes are, Cassandra has to
+# deserialize this much of the row to read a single column, so you want
+# it to be small - at least if you do many partial-row reads - but all
+# the index data is read for each access, so you don't want to generate
+# that wastefully either.
+column_index_size_in_kb: 64
+
+# Size limit for rows being compacted in memory.  Larger rows will spill
+# over to disk and use a slower two-pass compaction process.  A message
+# will be logged specifying the row key.
+#in_memory_compaction_limit_in_mb: 64
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# This setting has no effect on LeveledCompactionStrategy.
+#
+# concurrent_compactors defaults to the number of cores.
+# Uncomment to make compaction mono-threaded, the pre-0.8 default.
+#concurrent_compactors: 1
+
+# Multi-threaded compaction. When enabled, each compaction will use
+# up to one thread per core, plus one thread per sstable being merged.
+# This is usually only useful for SSD-based hardware: otherwise,
+# your concern is usually to get compaction to do LESS i/o (see:
+# compaction_throughput_mb_per_sec), not more.
+#multithreaded_compaction: false
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Track cached row keys during compaction, and re-cache their new
+# positions in the compacted sstable.  Disable if you use really large
+# key caches.
+#compaction_preheat_key_cache: true
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This improves cache locality
+#    when disabling read repair, which can further improve throughput.
+#    Only appropriate for single-datacenter deployments.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's
+#    IP address, respectively.  Unless this happens to match your
+#    deployment conventions (as it did Facebook's), this is best used
+#    as an example of writing a custom Snitch class.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region.  Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the Datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifer based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# index_interval controls the sampling of entries from the primrary
+# row index in terms of space versus time.  The larger the interval,
+# the smaller and less effective the sampling will be.  In technicial
+# terms, the interval coresponds to the number of index entries that
+# are skipped between taking each sample.  All the sampled entries
+# must fit in memory.  Generally, a value between 128 and 512 here
+# coupled with a large key cache size on CFs results in the best trade
+# offs.  This value is not often changed, however if you have many
+# very small rows (many to an OS page), then increasing this will
+# often lower memory usage without a impact on performance.
+index_interval: 128
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]

--- a/component/src/test/resources/log4j-surefire.properties
+++ b/component/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %5p {%c} - %x %m%n

--- a/component/src/test/resources/samples/cassandra-actions-test.bal
+++ b/component/src/test/resources/samples/cassandra-actions-test.bal
@@ -1,0 +1,96 @@
+import ballerina.data.cassandra as c;
+
+const int port = 9142;
+const string host = "localhost";
+const string username = "cassandra";
+const string password = "cassandra";
+
+struct RS {
+    int id;
+    string name;
+    float salary;
+    boolean married;
+}
+
+function testKeySpaceCreation() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {});
+    }
+    conn.update("CREATE KEYSPACE dummyks  WITH replication = {'class':'SimpleStrategy', 'replication_factor' :1}",
+    null);
+    conn.close();
+}
+
+function testTableCreation() {
+    endpoint<c:ClientConnector> conn {
+             create c:ClientConnector(host, port, username, password, {});
+    }
+    conn.update("CREATE TABLE peopleinfoks.student(id int PRIMARY KEY,name text, age int)", null);
+    conn.close();
+}
+
+function testInsert() {
+    endpoint<c:ClientConnector> conn {
+                 create c:ClientConnector(host, port, username, password, {});
+    }
+    c:Parameter pID = {cqlType:c:Type.INT, value:2};
+    c:Parameter pName = {cqlType:c:Type.TEXT, value:"Tim"};
+    c:Parameter pSalary = {cqlType:c:Type.FLOAT, value:100.5};
+    c:Parameter pIncome = {cqlType:c:Type.DOUBLE, value:1000.5};
+    c:Parameter pMarried = {cqlType:c:Type.BOOLEAN, value:true};
+    c:Parameter[] pUpdate = [pID, pName, pSalary, pIncome, pMarried];
+    conn.update("INSERT INTO peopleinfoks.person(id, name, salary, income, married) values (?,?,?,?,?)", pUpdate);
+    conn.close();
+}
+
+function testSelectWithParamArray() (int id, string name, float salary, boolean married) {
+    endpoint<c:ClientConnector> conn {
+                 create c:ClientConnector(host, port, username, password, {});
+    }
+
+    int[] intDataArray = [1, 5];
+    float[] floatDataArray = [100.2, 100.5];
+    float[] doubleDataArray = [10000.5, 11100.8];
+    string[] stringDataArray = ["Jack", "Jill"];
+    boolean[] booleanDataArray = [true, false];
+
+    c:Parameter idArray = {cqlType:c:Type.INT, value:intDataArray};
+    c:Parameter nameArray = {cqlType:c:Type.TEXT, value:stringDataArray};
+    c:Parameter salaryArray = {cqlType:c:Type.FLOAT, value:floatDataArray};
+    c:Parameter incomeArray = {cqlType:c:Type.DOUBLE, value:doubleDataArray};
+    c:Parameter marriageStatusArray = {cqlType:c:Type.BOOLEAN, value:booleanDataArray};
+
+    c:Parameter[] params = [idArray, nameArray, salaryArray, incomeArray, marriageStatusArray];
+
+    table dt = conn.select("SELECT id, name, salary, married FROM peopleinfoks.person WHERE id in (?) AND
+    name in (?) AND salary in (?) AND income in (?) AND married in (?) ALLOW FILTERING", params, typeof RS);
+
+    while (dt.hasNext()) {
+        var rs, _ = (RS) dt.getNext();
+        id = rs.id;
+        name = rs.name;
+        salary = rs.salary;
+        married = rs.married;
+    }
+    conn.close();
+    return;
+}
+
+function testSelect() (int id, string name, float salary) {
+    endpoint<c:ClientConnector> conn {
+                 create c:ClientConnector(host, port, username, password, {});
+    }
+    c:Parameter pID = {cqlType:c:Type.INT, value:1};
+    c:Parameter[] params = [pID];
+    table dt = conn.select("SELECT id, name, salary, married FROM peopleinfoks.person WHERE id = ?", params, typeof
+    RS);
+    while (dt.hasNext()) {
+            var rs, _ = (RS) dt.getNext();
+            id = rs.id;
+            name = rs.name;
+            salary = rs.salary;
+    }
+    conn.close();
+    return;
+}
+

--- a/component/src/test/resources/samples/cassandra-connection-init-test.bal
+++ b/component/src/test/resources/samples/cassandra-connection-init-test.bal
@@ -1,0 +1,134 @@
+import ballerina.data.cassandra as c;
+
+const int port = 9142;
+const string host = "localhost";
+const string username = "cassandra";
+const string password = "cassandra";
+
+function testConnectionInitWithLBPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {loadBalancingPolicy: "DCAwareRoundRobinPolicy"});
+    }
+    conn.update("CREATE KEYSPACE lbtestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor' :1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithInvalidLBPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {loadBalancingPolicy: "InvalidRoundRobinPolicy"});
+    }
+}
+
+function testConnectionInitWithRetryPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {retryPolicy:"DefaultRetryPolicy"});
+    }
+    conn.update("CREATE KEYSPACE retrytestkeyspace  WITH replication = {'class': 'SimpleStrategy', 'replication_factor':
+    1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithInvalidRetryPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {retryPolicy: "InvalidRetryPolicy"});
+    }
+    conn.close();
+}
+
+function testConnectionInitWithReconnectionPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {
+         reconnectionPolicy:"ConstantReconnectionPolicy", constantReconnectionPolicyDelay:500});
+    }
+    conn.update("CREATE KEYSPACE reconnectiontestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor': 1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithInvalidReconnectionPolicy() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {
+         reconnectionPolicy: "InvalidReconnectionPolicy", constantReconnectionPolicyDelay: 500});
+    }
+}
+
+function testConnectionInitWithInvalidConsistencyLevel() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {queryOptionsConfig: {
+         consistencyLevel: "INVALID_LEVEL"}});
+    }
+}
+
+function testConnectionInitWithInvalidSerialConsistencyLevel() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {queryOptionsConfig: {
+         serialConsistencyLevel: "ONE"}});
+    }
+}
+
+
+function testConnectionInitWithPoolingOptions() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {poolingOptionsConfig: {
+         maxRequestsPerConnectionLocal: 1, maxRequestsPerConnectionRemote: 128,    idleTimeoutSeconds: 120,
+         poolTimeoutMillis: 100,    maxQueueSize: 256,    heartbeatIntervalSeconds: 30,
+         coreConnectionsPerHostLocal: 2, maxConnectionsPerHostLocal: 2, newConnectionThresholdLocal: 100,
+         coreConnectionsPerHostRemote: 1, maxConnectionsPerHostRemote: 8, newConnectionThresholdRemote: 100}});
+    }
+    conn.update("CREATE KEYSPACE poolingoptionstestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor': 1}", null);
+    conn.close();
+}
+
+
+function testConnectionInitWithSocketOptions() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {socketOptionsConfig: {
+         connectTimeoutMillis: 5000, readTimeoutMillis: 12000, soLinger: 0}
+         });
+    }
+    conn.update("CREATE KEYSPACE socketoptionstestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor': 1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithQueryOptions() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {queryOptionsConfig: {
+         consistencyLevel: "ONE", serialConsistencyLevel: "LOCAL_SERIAL", defaultIdempotence: false, metadataEnabled:
+          true, reprepareOnUp: true, prepareOnAllHosts:true, fetchSize: 5000, maxPendingRefreshNodeListRequests: 20,
+         maxPendingRefreshNodeRequests: 20, maxPendingRefreshSchemaRequests: 20, refreshNodeListIntervalMillis: 1000,
+         refreshNodeIntervalMillis: 1000, refreshSchemaIntervalMillis: 1000}});
+    }
+    conn.update("CREATE KEYSPACE queryoptionstestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor': 1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithProtocolOptions() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {protocolOptionsConfig: {
+         sslEnabled: false, noCompact: false, maxSchemaAgreementWaitSeconds: 10, compression: "NONE",
+         initialProtocolVersion:"V4"}});
+    }
+    conn.update("CREATE KEYSPACE protocoloptionstestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor' :1}", null);
+    conn.close();
+}
+
+function testConnectionInitWithAdditionalConnectionParams() {
+    endpoint<c:ClientConnector> conn {
+         create c:ClientConnector(host, port, username, password, {clusterName: "Maze", withoutMetrics:
+         false, withoutJMXReporting: false, allowRemoteDCsForLocalConsistencyLevel: false});
+    }
+    conn.update("CREATE KEYSPACE conparamtestkeyspace  WITH replication = {'class': 'SimpleStrategy',
+    'replication_factor': 1}", null);
+    conn.close();
+}
+
+
+
+
+
+

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<suite name="MongoDBConnector_IntegrationTest_Suite" verbose="1">
+    <test name="Cassandra-Connector-Tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.ballerinalang.data.cassandra.actions.CassandraBaseTest"/>
+            <class name="org.ballerinalang.data.cassandra.actions.CassandraActionsTest"/>
+            <class name="org.ballerinalang.data.cassandra.actions.CassandraConnectionInitTest"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,29 @@
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${cassandra.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.cassandraunit</groupId>
+                <artifactId>cassandra-unit</artifactId>
+                <version>${cassandraunit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.ballerinalang</groupId>
+                <artifactId>ballerina-launcher</artifactId>
+                <version>${ballerina.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${findbugs.annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -174,12 +197,51 @@
                 <version>${maven.deploy.plugin.version}</version>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.bsc.maven</groupId>
+                    <artifactId>maven-processor-plugin</artifactId>
+                    <version>${mvn.processor.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${maven.checkstyle.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.ballerinalang</groupId>
+                    <artifactId>docerina-maven-plugin</artifactId>
+                    <version>${docerina.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>${maven.findbugsplugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${maven.jacoco.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <properties>
         <project.scm.id>my-scm-server</project.scm.id>
-        <ballerina.version>0.95.6</ballerina.version>
-        <cassandra.version>3.1.3</cassandra.version>
+        <ballerina.version>0.961.0</ballerina.version>
+        <cassandra.version>3.4.0</cassandra.version>
         <com.google.guava.version>19.0</com.google.guava.version>
         <io.dropwizard.metrics.version>3.1.2</io.dropwizard.metrics.version>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
@@ -194,6 +256,12 @@
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+        <cassandraunit.version>3.3.0.2</cassandraunit.version>
+        <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
+        <maven.jacoco.plugin.version>0.8.0</maven.jacoco.plugin.version>
+        <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
+        <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
+        <slf4j.version>1.7.25</slf4j.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Purpose
This adds missing query param support and unit tests to cassandra connector. In addition adds jacoco coverage report generation with some improvments to the pom.xmls. Fixes ballerina-lang/connector-cassandra#11, ballerina-lang/connector-cassandra#12 and ballerina-lang/connector-cassandra#14

## Automation tests
 - Unit tests 
  Added.
Instruction coverage: 86%
Branch coverage: 62%

## Security checks
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8.141, Cassandra 3.11
 